### PR TITLE
feat: bridge improvements — always show interface, contextual wallet toasts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-day-picker": "^9.14.0",
         "react-dom": "19.2.4",
         "react-router-dom": "^7.13.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "torph": "^0.0.9",
         "viem": "^2.46.3",
@@ -12107,6 +12108,16 @@
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.4",
     "react-router-dom": "^7.13.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "torph": "^0.0.9",
     "viem": "^2.46.3",

--- a/src/components/layout/sidebar/sidebar.tsx
+++ b/src/components/layout/sidebar/sidebar.tsx
@@ -31,7 +31,7 @@ export default function Sidebar() {
         </nav>
         <Button
           variant="default"
-          label="Start new bridge"
+          label="Bridge"
           icon={<Plus size={16} />}
           path={routes.bridge.path}
           isInternalLink

--- a/src/domains/bridge/react/bridge.page.tsx
+++ b/src/domains/bridge/react/bridge.page.tsx
@@ -3,25 +3,10 @@ import BridgeInitialStep from "./components/steps/bridge-initial-step";
 import BridgeSuccessStep from "./components/steps/bridge-success-step";
 import { useBridge } from "@/hooks/useBridge";
 import { useBridgeHealthContext } from "@/providers/BridgeHealthProvider";
-import NoWalletConnectedPanel from "@/components/no-wallet-connected-panel";
 
 export default function BridgePage() {
   const bridge = useBridge();
   const { isPaused } = useBridgeHealthContext();
-
-  const walletsConnectedPanelLabel =
-    !bridge.solanaConnected && !bridge.qubicConnected
-      ? "No wallet connected."
-      : "One wallet missing.";
-
-  if (!bridge.solanaConnected || !bridge.qubicConnected) {
-    return (
-      <NoWalletConnectedPanel
-        label={walletsConnectedPanelLabel}
-        description="Both wallets need to be connected to bridge your tokens."
-      />
-    );
-  }
 
   return (
     <div className={cn("flex w-full flex-col gap-10", "p-0 py-8 xl:p-8")}>

--- a/src/domains/history/react/components/empty-history.tsx
+++ b/src/domains/history/react/components/empty-history.tsx
@@ -14,7 +14,7 @@ export default function EmptyHistory() {
 
       <Button
         variant="default"
-        label="Start new bridge"
+        label="Bridge"
         icon={<Plus size={16} />}
         path={routes.bridge.path}
         isInternalLink

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { toast } from "sonner";
 import type { NetworkTagNetwork } from "@/components/network-tag/network-tag";
 import type { NetworkDirectionInformationProps } from "@/components/network-direction-information/network-direction-information";
 import type { Address } from "viem";
@@ -57,13 +58,15 @@ export function useBridge() {
   const handleBridge = async () => {
     setLocalError(null);
 
-    if (!solanaWallet.address) {
-      setLocalError("Connect your Solana wallet first");
+    const originConnected = isSolanaToQubic ? !!solanaWallet.address : !!qubicWallet.address;
+    if (!originConnected) {
+      toast.error(`Please connect your ${isSolanaToQubic ? "Solana" : "Qubic"} wallet`);
       return;
     }
 
-    if (!qubicWallet.address) {
-      setLocalError("Connect your Qubic wallet first");
+    const destinationConnected = isSolanaToQubic ? !!qubicWallet.address : !!solanaWallet.address;
+    if (!destinationConnected) {
+      toast.error(`Please connect your ${isSolanaToQubic ? "Qubic" : "Solana"} wallet`);
       return;
     }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import WalletProviders from "@/providers/WalletProviders";
 import ModalProvider from "@/providers/modal-provider";
+import { Toaster } from "sonner";
 import "@/styles/index.css";
 import App from "@/App";
 
@@ -13,6 +14,7 @@ createRoot(document.getElementById("root")!).render(
       <WalletProviders>
         <App />
         <ModalProvider />
+        <Toaster position="bottom-right" richColors />
       </WalletProviders>
     </BrowserRouter>
   </StrictMode>,


### PR DESCRIPTION
## Summary

- **Rename CTA**: "Start new bridge" button is now labeled "Bridge" in the sidebar and empty history page.
- **Remove wallet gate**: The bridge page no longer blocks the entire interface when a wallet is missing. The form is always rendered, giving users full visibility into the bridge UI regardless of connection state.
- **Contextual wallet toasts**: When the Bridge button is clicked without the required wallets connected, a `sonner` toast fires with a message specific to the bridge direction — e.g. *"Please connect your Solana wallet"* when Solana→Qubic and the Solana wallet is missing, or *"Please connect your Qubic wallet"* when Qubic→Solana and the Qubic wallet is missing. Amount/fee validation errors remain as inline messages below the form.

## Changes

| File | Change |
|------|--------|
| `src/components/layout/sidebar/sidebar.tsx` | Label → "Bridge" |
| `src/domains/history/react/components/empty-history.tsx` | Label → "Bridge" |
| `src/domains/bridge/react/bridge.page.tsx` | Remove early return / NoWalletConnectedPanel gate |
| `src/hooks/useBridge.ts` | Wallet checks → `toast.error()` with origin-aware message |
| `src/main.tsx` | Add `<Toaster position="bottom-right" richColors />` |
| `package.json` | Add `sonner` dependency |

## Test plan

- [ ] Sidebar and empty history page display "Bridge" as the button label
- [ ] Navigating to `/bridge` with no wallets connected shows the full form (no blocking panel)
- [ ] Clicking Bridge with Solana as origin and Solana wallet missing → toast "Please connect your Solana wallet"
- [ ] Clicking Bridge with Qubic as origin and Qubic wallet missing → toast "Please connect your Qubic wallet"
- [ ] Clicking Bridge with origin connected but destination missing → toast naming the destination wallet
- [ ] Amount/fee validation errors still appear inline below the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)