### PR TITLE
fix: correct stale byte offsets and discriminators after sc changes

### DIFF
--- a/src/hooks/useAdminRoles.ts
+++ b/src/hooks/useAdminRoles.ts
@@ -26,7 +26,7 @@ export function decodeSolanaAdmin(data: Uint8Array): string | null {
 }
 
 export function decodeSolanaPaused(data: Uint8Array): boolean {
-  return data.length >= 110 && data[109] !== 0;
+  return data.length >= 143 && data[142] !== 0;
 }
 
 interface SolanaGlobalState {
@@ -41,16 +41,18 @@ interface SolanaGlobalState {
 
 function decodeSolanaGlobalState(data: Uint8Array): SolanaGlobalState | null {
   try {
-    if (data.length < 112) return null;
+    if (data.length < 145) return null;
     const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    // Layout: key(1) admin(32) pendingAdmin(33) protocolFeeRecipient(32) tokenMint(32)
+    //         owedProtocolFee(8) bpsFee(2) protocolFeeBpsOfBps(2) paused(1) oracleCount(1) bump(1)
     return {
       admin: new PublicKey(data.slice(1, 33)).toBase58(),
-      protocolFeeRecipient: new PublicKey(data.slice(33, 65)).toBase58(),
-      tokenMint: new PublicKey(data.slice(65, 97)).toBase58(),
-      owedProtocolFee: view.getBigUint64(97, true),
-      bpsFee: view.getUint16(105, true),
-      protocolFeeBpsOfBps: view.getUint16(107, true),
-      paused: data[109] !== 0,
+      protocolFeeRecipient: new PublicKey(data.slice(66, 98)).toBase58(),
+      tokenMint: new PublicKey(data.slice(98, 130)).toBase58(),
+      owedProtocolFee: view.getBigUint64(130, true),
+      bpsFee: view.getUint16(138, true),
+      protocolFeeBpsOfBps: view.getUint16(140, true),
+      paused: data[142] !== 0,
     };
   } catch {
     return null;

--- a/src/hooks/useSolanaAdmin.ts
+++ b/src/hooks/useSolanaAdmin.ts
@@ -108,9 +108,9 @@ export function useSolanaAdmin(): SolanaAdminActions {
   const unpause = useCallback(
     () =>
       run(async () => {
-        const pauser = new PublicKey(address!);
-        const ix = createUnpauseInstruction(pauser);
-        return sendTransaction(provider!, solanaConnection, ix, pauser);
+        const admin = new PublicKey(address!);
+        const ix = createUnpauseInstruction(admin);
+        return sendTransaction(provider!, solanaConnection, ix, admin);
       }),
     [provider, address],
   );

--- a/src/lib/bridge/solana/instructions/claim-oracle-fee.ts
+++ b/src/lib/bridge/solana/instructions/claim-oracle-fee.ts
@@ -7,7 +7,7 @@ import {
 } from "../constants";
 import { GLOBAL_STATE_PDA, deriveOraclePda } from "../pda";
 
-const CLAIM_ORACLE_FEE_DISCRIMINATOR = 0x0b;
+const CLAIM_ORACLE_FEE_DISCRIMINATOR = 0x0d;
 
 function deriveAta(owner: PublicKey, mint: PublicKey): PublicKey {
   return PublicKey.findProgramAddressSync(

--- a/src/lib/bridge/solana/instructions/claim-protocol-fee.ts
+++ b/src/lib/bridge/solana/instructions/claim-protocol-fee.ts
@@ -7,7 +7,7 @@ import {
 } from "../constants";
 import { GLOBAL_STATE_PDA } from "../pda";
 
-const CLAIM_PROTOCOL_FEE_DISCRIMINATOR = 0x0a;
+const CLAIM_PROTOCOL_FEE_DISCRIMINATOR = 0x0c;
 
 function deriveAta(owner: PublicKey, mint: PublicKey): PublicKey {
   return PublicKey.findProgramAddressSync(

--- a/src/lib/bridge/solana/instructions/pause-unpause.ts
+++ b/src/lib/bridge/solana/instructions/pause-unpause.ts
@@ -6,15 +6,10 @@ import { GLOBAL_STATE_PDA, derivePauserPda } from "../pda";
 const PAUSE_DISCRIMINATOR = 0x05;
 const UNPAUSE_DISCRIMINATOR = 0x06;
 
-function createPauseUnpauseInstruction(
-  discriminator: number,
-  pauser: PublicKey,
-): TransactionInstruction {
+export function createPauseInstruction(pauser: PublicKey): TransactionInstruction {
   const pauserPda = derivePauserPda(pauser);
-
   const data = Buffer.alloc(1);
-  data.writeUInt8(discriminator, 0);
-
+  data.writeUInt8(PAUSE_DISCRIMINATOR, 0);
   return new TransactionInstruction({
     programId: PROGRAM_ID,
     keys: [
@@ -26,10 +21,16 @@ function createPauseUnpauseInstruction(
   });
 }
 
-export function createPauseInstruction(pauser: PublicKey): TransactionInstruction {
-  return createPauseUnpauseInstruction(PAUSE_DISCRIMINATOR, pauser);
-}
-
-export function createUnpauseInstruction(pauser: PublicKey): TransactionInstruction {
-  return createPauseUnpauseInstruction(UNPAUSE_DISCRIMINATOR, pauser);
+// Unpause is admin-only — no PauserPDA account.
+export function createUnpauseInstruction(admin: PublicKey): TransactionInstruction {
+  const data = Buffer.alloc(1);
+  data.writeUInt8(UNPAUSE_DISCRIMINATOR, 0);
+  return new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [
+      { pubkey: admin, isSigner: true, isWritable: true },
+      { pubkey: GLOBAL_STATE_PDA, isSigner: false, isWritable: true },
+    ],
+    data,
+  });
 }


### PR DESCRIPTION
- fix global state decoder offsets shifted by 33 bytes (pending_admin field)
- fix claim protocol fee discriminator 0x0a → 0x0c
- fix claim oracle fee discriminator 0x0b → 0x0d
- fix unpause instruction: admin-only, 2 accounts (no pauser pda)