### PR TITLE
feat: impose hub median relayer fee; block bridge without estimate

### DIFF
--- a/src/domains/bridge/react/bridge.page.tsx
+++ b/src/domains/bridge/react/bridge.page.tsx
@@ -21,12 +21,13 @@ export default function BridgePage() {
           bridgeAmount={bridge.bridgeAmount}
           setBridgeAmount={bridge.setBridgeAmount}
           relayFeeDisplay={bridge.relayFeeDisplay}
-          onRelayFeeDisplayChange={bridge.setRelayFeeDisplay}
           originNetwork={bridge.originNetwork}
           destinationNetwork={bridge.destinationNetwork}
           onSwitchDirection={bridge.switchDirection}
           onBridge={bridge.handleBridge}
           isBridging={bridge.isBridging}
+          canBridge={bridge.canBridge}
+          isEstimating={bridge.isEstimating}
           originWalletConfig={bridge.originWalletConfig}
           destinationWalletConfig={bridge.destinationWalletConfig}
           feesAmount={bridge.totalProgramFees}

--- a/src/domains/bridge/react/components/bridge-amount-section.tsx
+++ b/src/domains/bridge/react/components/bridge-amount-section.tsx
@@ -12,7 +12,7 @@ interface Props {
   feesAmount?: string;
   relayFeesDisplay: string;
   setAmount: (amount: string) => void;
-  onRelayFeeDisplayChange?: (display: string) => void;
+  isLoadingFees?: boolean;
 }
 
 export default function BridgeAmountSection({
@@ -23,7 +23,7 @@ export default function BridgeAmountSection({
   feesAmount = "0",
   relayFeesDisplay,
   setAmount,
-  onRelayFeeDisplayChange,
+  isLoadingFees = false,
 }: Props) {
   function setMax() {
     setAmount(balance);
@@ -66,8 +66,7 @@ export default function BridgeAmountSection({
           feesAmount={feesAmount}
           relayFeesAmount={relayFeesDisplay}
           currency={destinationCurrency}
-          canEdit={!!onRelayFeeDisplayChange}
-          onRelayFeeChange={onRelayFeeDisplayChange}
+          isLoading={isLoadingFees}
         />
       </div>
     </div>

--- a/src/domains/bridge/react/components/fees-dropdown.tsx
+++ b/src/domains/bridge/react/components/fees-dropdown.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback, useEffect } from "react";
-import { ChevronDown, ChevronUp, Edit, Info } from "lucide-react";
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Info } from "lucide-react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import Tooltip from "@/components/ui/tooltip";
 import type { Currency } from "@/types/currency";
@@ -8,44 +8,25 @@ interface Props {
   feesAmount: string;
   relayFeesAmount: string;
   currency: Currency;
-  canEdit?: boolean;
-  onRelayFeeChange?: (raw: string) => void;
+  isLoading?: boolean;
 }
 
 export default function FeesDropdown({
   feesAmount,
   relayFeesAmount,
   currency,
-  canEdit = false,
-  onRelayFeeChange,
+  isLoading = false,
 }: Props) {
   const [open, setOpen] = useState(false);
-  const [editing, setEditing] = useState(false);
-  const [editValue, setEditValue] = useState(relayFeesAmount);
-
-  const autoFocusRef = useCallback((node: HTMLInputElement | null) => {
-    if (node !== null) node.focus();
-  }, []);
-
-  useEffect(() => {
-    if (!editing) setEditValue(relayFeesAmount);
-  }, [relayFeesAmount, editing]);
 
   const totalFees = (parseFloat(feesAmount) + parseFloat(relayFeesAmount)).toString();
-
-  function handleEditConfirm() {
-    const parsed = parseFloat(editValue);
-    const value = isFinite(parsed) && parsed >= 0 ? editValue : "0";
-    onRelayFeeChange?.(value || "0");
-    setEditing(false);
-  }
 
   return (
     <DropdownMenu.Root open={open} onOpenChange={setOpen}>
       <DropdownMenu.Trigger asChild>
         <div className="flex flex-wrap items-center gap-1 cursor-pointer">
           <span className="text-xs text-primary">
-            Subtracted fees: {totalFees} {currency}
+            {isLoading ? "Calculating fees…" : `Subtracted fees: ${totalFees} ${currency}`}
           </span>
 
           <Tooltip content="Included gas is paid on top of the amount and covers solvers' gas costs to fulfill your trade.">
@@ -77,65 +58,20 @@ export default function FeesDropdown({
           className="z-50 flex flex-col gap-3 bg-primary p-4 rounded-lg min-w-[400px] shadow-lg"
           sideOffset={8}
           align="center"
-          onCloseAutoFocus={(e) => {
-            if (editing) e.preventDefault();
-          }}
         >
           <div className="flex flex-col gap-4">
             <div className="flex items-center justify-between gap-4">
               <span className="text-sm text-white">Estimated fees</span>
               <span className="text-sm font-semibold text-white">
-                {feesAmount} {currency}
+                {isLoading ? "…" : `${feesAmount} ${currency}`}
               </span>
             </div>
 
             <div className="flex items-center justify-between gap-4">
-              <div className="flex items-center gap-3">
-                <span className="text-sm text-white">Relayer fees</span>
-
-                {canEdit && !editing && (
-                  <button
-                    type="button"
-                    className="flex items-center gap-1 cursor-pointer"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setEditing(true);
-                    }}
-                  >
-                    <span className="text-sm text-white underline">Edit</span>
-                    <Edit size={14} className="text-white shrink-0" aria-hidden />
-                  </button>
-                )}
-              </div>
-
-              {editing ? (
-                <div className="flex items-center gap-2">
-                  <input
-                    ref={autoFocusRef}
-                    type="text"
-                    inputMode="decimal"
-                    value={editValue}
-                    onChange={(e) => setEditValue(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") handleEditConfirm();
-                      if (e.key === "Escape") setEditing(false);
-                    }}
-                    className="w-24 rounded border border-white/30 bg-white/10 px-2 py-1 text-sm font-semibold text-white text-right outline-none focus:border-white"
-                  />
-                  <span className="text-sm text-white">{currency}</span>
-                  <button
-                    type="button"
-                    onClick={handleEditConfirm}
-                    className="rounded bg-white/20 px-2 py-1 text-xs text-white hover:bg-white/30"
-                  >
-                    OK
-                  </button>
-                </div>
-              ) : (
-                <span className="text-sm font-semibold text-white">
-                  {relayFeesAmount} {currency}
-                </span>
-              )}
+              <span className="text-sm text-white">Relayer fees</span>
+              <span className="text-sm font-semibold text-white">
+                {isLoading ? "…" : `${relayFeesAmount} ${currency}`}
+              </span>
             </div>
           </div>
         </DropdownMenu.Content>

--- a/src/domains/bridge/react/components/steps/bridge-initial-step.tsx
+++ b/src/domains/bridge/react/components/steps/bridge-initial-step.tsx
@@ -12,17 +12,18 @@ interface Props {
   bridgeAmount: string;
   setBridgeAmount: (amount: string) => void;
   relayFeeDisplay: string;
-  onRelayFeeDisplayChange: (display: string) => void;
   originNetwork: NetworkTagNetwork;
   destinationNetwork: NetworkTagNetwork;
   onSwitchDirection: () => void;
   onBridge: () => void;
   isBridging: boolean;
+  canBridge: boolean;
+  isEstimating: boolean;
   originWalletConfig: NetworkDirectionInformationProps;
   destinationWalletConfig: NetworkDirectionInformationProps;
   feesAmount: string;
   error: string | null;
-  isSolanaToQubic: boolean;
+  isSolanaToQubic?: boolean;
   isPaused?: boolean;
 }
 
@@ -30,19 +31,21 @@ export default function BridgeInitialStep({
   bridgeAmount,
   setBridgeAmount,
   relayFeeDisplay,
-  onRelayFeeDisplayChange,
   originNetwork,
   destinationNetwork,
   onSwitchDirection,
   onBridge,
   isBridging,
+  canBridge,
+  isEstimating,
   originWalletConfig,
   destinationWalletConfig,
   feesAmount,
   error,
-  isSolanaToQubic,
   isPaused,
 }: Props) {
+  const isBridgeDisabled = isPaused || !canBridge || isBridging;
+
   return (
     <>
       <div className="grid grid-cols-2 gap-10">
@@ -68,7 +71,7 @@ export default function BridgeInitialStep({
               relayFeesDisplay={relayFeeDisplay}
               amount={bridgeAmount}
               setAmount={setBridgeAmount}
-              onRelayFeeDisplayChange={isSolanaToQubic ? onRelayFeeDisplayChange : undefined}
+              isLoadingFees={isEstimating}
             />
           </div>
 
@@ -114,11 +117,11 @@ export default function BridgeInitialStep({
         <span className="col-span-1 col-start-2">
           <Button
             variant="default"
-            label={isPaused ? "Bridge (paused)" : "Bridge"}
+            label={isPaused ? "Bridge (paused)" : isEstimating ? "Calculating fees…" : "Bridge"}
             action={onBridge}
             isFullWidth
             isLoading={isBridging}
-            isDisabled={isPaused}
+            isDisabled={isBridgeDisabled}
           />
         </span>
       </div>

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -16,12 +16,9 @@ import { queryGetConfig } from "@/lib/bridge/qubic/query";
 
 export type BridgeSteps = "initial" | "successful";
 
-const DEFAULT_RELAYER_FEE_DISPLAY = "1000";
-
 export function useBridge() {
   const [currentBridgeStep, setCurrentBridgeStep] = useState<BridgeSteps>("initial");
   const [bridgeAmount, setBridgeAmount] = useState("");
-  const [relayFeeDisplay, setRelayFeeDisplay] = useState(DEFAULT_RELAYER_FEE_DISPLAY);
   const [originNetwork, setOriginNetwork] = useState<NetworkTagNetwork>(NETWORK.Solana);
   const [localError, setLocalError] = useState<string | null>(null);
 
@@ -58,6 +55,11 @@ export function useBridge() {
   const handleBridge = async () => {
     setLocalError(null);
 
+    if (!estimate) {
+      setLocalError("Fee estimation unavailable. Please try again.");
+      return;
+    }
+
     const originConnected = isSolanaToQubic ? !!solanaWallet.address : !!qubicWallet.address;
     if (!originConnected) {
       toast.error(`Please connect your ${isSolanaToQubic ? "Solana" : "Qubic"} wallet`);
@@ -76,7 +78,8 @@ export function useBridge() {
       return;
     }
 
-    const totalFees = parseFloat(totalProgramFees) + parseFloat(effectiveRelayFee);
+    const relayerFee = estimate.relayerFee;
+    const totalFees = parseFloat(totalProgramFees) + parseFloat(relayerFee);
     if (amountValue <= totalFees) {
       setLocalError(`Amount must be greater than total fees (${Math.ceil(totalFees)} QUBIC)`);
       return;
@@ -90,14 +93,14 @@ export function useBridge() {
       result = await bridge.sendOutbound({
         amount: displayToRaw(bridgeAmount),
         toAddress,
-        relayerFee: displayToRaw(effectiveRelayFee),
+        relayerFee: displayToRaw(relayerFee),
         orderEra,
       });
     } else {
       result = await inbound.sendLock({
         amount: BigInt(Math.floor(parseFloat(bridgeAmount))),
         toSolanaAddress: solanaWallet.address as string,
-        relayerFee: BigInt(Math.floor(parseFloat(effectiveRelayFee))),
+        relayerFee: BigInt(Math.floor(parseFloat(relayerFee))),
       });
     }
 
@@ -131,7 +134,6 @@ export function useBridge() {
     bridge.reset();
     inbound.reset();
     setBridgeAmount("");
-    setRelayFeeDisplay(DEFAULT_RELAYER_FEE_DISPLAY);
     setLocalError(null);
     setCurrentBridgeStep("initial");
   };
@@ -169,14 +171,14 @@ export function useBridge() {
       };
 
   const totalProgramFees = estimate?.totalBridgeFee ?? "0";
-  const effectiveRelayFee = estimate?.relayerFee ?? relayFeeDisplay;
+  const relayerFee = estimate?.relayerFee ?? "0";
+  const canBridge = !!estimate && !isEstimating;
 
   return {
     currentBridgeStep,
     bridgeAmount,
     setBridgeAmount,
-    relayFeeDisplay: effectiveRelayFee,
-    setRelayFeeDisplay,
+    relayFeeDisplay: relayerFee,
     originNetwork,
     destinationNetwork,
     isSolanaToQubic,
@@ -189,6 +191,7 @@ export function useBridge() {
     totalProgramFees,
     isBridging: bridge.isLoading || inbound.isLoading,
     isEstimating,
+    canBridge,
     error:
       localError ?? bridge.outboundError ?? inbound.inboundError ?? estimateError ?? trackingError,
     txResult: isSolanaToQubic ? bridge.txResult : inbound.txResult,

--- a/src/lib/bridge/solana/constants.ts
+++ b/src/lib/bridge/solana/constants.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from "@solana/web3.js";
 
-export const PROGRAM_ID = new PublicKey("qSBGtee9tspoDVmb867Wq6tcR3kp19XN1PbBVckrH7H");
+export const PROGRAM_ID = new PublicKey("9HzXq7P6UEQjJCrvbPCt4eZRvkoJU9jo1mSssbMHkncQ");
 
 export const TOKEN_PROGRAM_ID = new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 export const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey(

--- a/src/lib/hub/hub.types.ts
+++ b/src/lib/hub/hub.types.ts
@@ -81,9 +81,7 @@ export type HubOracleHealth = {
   url: string;
   status: "ok" | "down";
   timestamp: string;
-  /** Minimum relayer fee (QU) for Qubic→Solana orders. */
   relayerFeeToSolana: string;
-  /** Minimum relayer fee (QU) for Solana→Qubic orders. */
   relayerFeeToQubic: string;
 };
 

--- a/src/lib/hub/hub.types.ts
+++ b/src/lib/hub/hub.types.ts
@@ -81,8 +81,10 @@ export type HubOracleHealth = {
   url: string;
   status: "ok" | "down";
   timestamp: string;
-  relayerFeeSolana: string;
-  relayerFeeQubic: string;
+  /** Minimum relayer fee (QU) for Qubic→Solana orders. */
+  relayerFeeToSolana: string;
+  /** Minimum relayer fee (QU) for Solana→Qubic orders. */
+  relayerFeeToQubic: string;
 };
 
 export type HubOraclesHealthResponse = {


### PR DESCRIPTION
- Remove editable relay fee from UI (FeesDropdown, BridgeAmountSection, BridgeInitialStep); fee now comes exclusively from hub estimate
- Add canBridge = !!estimate && !isEstimating — Bridge button is disabled and shows "Calculating fees…" until a valid estimate is available
- Guard handleBridge with early return when estimate is missing
- Rename HubOracleHealth fields relayerFeeSolana/Qubic → relayerFeeToSolana/Qubic