### PR TITLE
fix: track orders by source nonce instead of transaction hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "prepare": "husky",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test": "vitest",
+    "test": "vitest --run",
+    "test:watch": "vitest",
     "test:ui": "vitest --ui"
   },
   "dependencies": {

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -10,6 +10,7 @@ import { useBridgeOutbound } from "@/hooks/useBridgeOutbound";
 import { useBridgeInbound } from "@/hooks/useBridgeInbound";
 import { qubicIdentityToBytes } from "@/lib/bridge/qubicAddress";
 import { displayToRaw } from "@/lib/bridge/amounts";
+import { bytesToHex } from "@/lib/qubicIdentity";
 import { useFeeEstimate } from "@/hooks/useFeeEstimate";
 import { useOrderTracking } from "@/hooks/useOrderTracking";
 import { queryGetConfig } from "@/lib/bridge/qubic/query";
@@ -30,16 +31,20 @@ export function useBridge() {
   const isSolanaToQubic = originNetwork === NETWORK.Solana;
   const destinationNetwork = isSolanaToQubic ? NETWORK.Qubic : NETWORK.Solana;
 
-  const activeTxSignature = isSolanaToQubic
-    ? bridge.txResult?.signature
-    : inbound.txResult?.signature;
+  const activeSourceNonce = isSolanaToQubic
+    ? bridge.lastOrder
+      ? bytesToHex(bridge.lastOrder.nonce)
+      : null
+    : inbound.lastLock
+      ? "0".repeat(56) + inbound.lastLock.nonce.toString(16).padStart(8, "0")
+      : null;
 
   const {
     orderStatus,
     destinationTrxHash,
     isPolling: isTrackingOrder,
     trackingError,
-  } = useOrderTracking(activeTxSignature ?? null);
+  } = useOrderTracking(activeSourceNonce);
 
   const { estimate, isEstimating, estimateError } = useFeeEstimate(
     originNetwork,

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -31,13 +31,15 @@ export function useBridge() {
   const isSolanaToQubic = originNetwork === NETWORK.Solana;
   const destinationNetwork = isSolanaToQubic ? NETWORK.Qubic : NETWORK.Solana;
 
-  const activeSourceNonce = isSolanaToQubic
-    ? bridge.lastOrder
-      ? bytesToHex(bridge.lastOrder.nonce)
-      : null
-    : inbound.lastLock
-      ? "0".repeat(56) + inbound.lastLock.nonce.toString(16).padStart(8, "0")
-      : null;
+  let activeSourceNonce: string | null = null;
+
+  if (isSolanaToQubic) {
+    if (bridge.lastOrder) {
+      activeSourceNonce = bytesToHex(bridge.lastOrder.nonce);
+    }
+  } else if (inbound.lastLock) {
+    activeSourceNonce = "0".repeat(56) + inbound.lastLock.nonce.toString(16).padStart(8, "0");
+  }
 
   const {
     orderStatus,

--- a/src/hooks/useOrderTracking.ts
+++ b/src/hooks/useOrderTracking.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { fetchOrderByTrxHash, HubApiError } from "@/lib/hub/hub-client";
+import { fetchOrderBySourceNonce, HubApiError } from "@/lib/hub/hub-client";
 import { mapHubStatus } from "@/lib/hub/hub-mappers";
 import type { OrderStatus } from "@/domains/activity/activity.types";
 
@@ -9,7 +9,7 @@ const MAX_DURATION_MS = 10 * 60 * 1_000;
 
 const TERMINAL_STATUSES: OrderStatus[] = ["finalized", "failed"];
 
-export function useOrderTracking(txSignature: string | null) {
+export function useOrderTracking(sourceNonce: string | null) {
   const [orderStatus, setOrderStatus] = useState<OrderStatus | null>(null);
   const [destinationTrxHash, setDestinationTrxHash] = useState<string | null>(null);
   const [isPolling, setIsPolling] = useState(false);
@@ -17,7 +17,7 @@ export function useOrderTracking(txSignature: string | null) {
   const startedAt = useRef<number>(0);
 
   useEffect(() => {
-    if (!txSignature) {
+    if (!sourceNonce) {
       setOrderStatus(null);
       setDestinationTrxHash(null);
       setIsPolling(false);
@@ -44,8 +44,8 @@ export function useOrderTracking(txSignature: string | null) {
       }
 
       try {
-        if (!txSignature) return;
-        const res = await fetchOrderByTrxHash(txSignature, controller.signal);
+        if (!sourceNonce) return;
+        const res = await fetchOrderBySourceNonce(sourceNonce, controller.signal);
         if (controller.signal.aborted) return;
 
         const status = mapHubStatus(res.data.status);
@@ -77,7 +77,7 @@ export function useOrderTracking(txSignature: string | null) {
       controller.abort();
       clearTimeout(timeoutId);
     };
-  }, [txSignature]);
+  }, [sourceNonce]);
 
   return { orderStatus, destinationTrxHash, isPolling, trackingError };
 }

--- a/src/lib/bridge/solana/send.ts
+++ b/src/lib/bridge/solana/send.ts
@@ -56,7 +56,15 @@ export async function sendTransaction(
     throw new Error("Transaction was rejected");
   }
 
-  await connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight }, "confirmed");
+  const result = await connection.confirmTransaction(
+    { signature, blockhash, lastValidBlockHeight },
+    "confirmed",
+  );
+
+  if (result.value.err) {
+    const errDetail = JSON.stringify(result.value.err);
+    throw new Error(`Transaction failed on-chain: ${errDetail}`);
+  }
 
   return {
     signature,

--- a/src/lib/hub/hub-client.ts
+++ b/src/lib/hub/hub-client.ts
@@ -1,7 +1,7 @@
 import type {
   HubOrdersQuery,
   HubOrdersResponse,
-  HubOrderByTrxHashResponse,
+  HubOrderBySourceNonceResponse,
   HubEstimateBody,
   HubEstimateResponse,
   HubBridgeHealth,
@@ -52,13 +52,16 @@ export function fetchOrders(
   return hubFetch<HubOrdersResponse>(`/api/orders${qs ? `?${qs}` : ""}`, { signal });
 }
 
-export function fetchOrderByTrxHash(
-  hash: string,
+export function fetchOrderBySourceNonce(
+  nonce: string,
   signal?: AbortSignal,
-): Promise<HubOrderByTrxHashResponse> {
-  return hubFetch<HubOrderByTrxHashResponse>(`/api/orders/trx-hash/${encodeURIComponent(hash)}`, {
-    signal,
-  });
+): Promise<HubOrderBySourceNonceResponse> {
+  return hubFetch<HubOrderBySourceNonceResponse>(
+    `/api/orders/source-nonce/${encodeURIComponent(nonce)}`,
+    {
+      signal,
+    },
+  );
 }
 
 export function estimateFees(

--- a/src/lib/hub/hub.types.ts
+++ b/src/lib/hub/hub.types.ts
@@ -44,7 +44,7 @@ export type HubOrderWithSignatures = HubOrder & {
   signatures: string[];
 };
 
-export type HubOrderByTrxHashResponse = {
+export type HubOrderBySourceNonceResponse = {
   data: HubOrderWithSignatures;
 };
 


### PR DESCRIPTION
Compute source nonce from the in-memory nonce (Uint8Array for Solana, uint32 number for Qubic) and poll /api/orders/source-nonce/:nonce instead of /api/orders/trx-hash/:hash. Fixes order tracking for Qubic→Solana orders where the tx ID never matched the stored hash.