### PR TITLE
feat: allow custom recipient address on bridge destination

### DIFF
--- a/src/components/network-direction-information/network-direction-information.tsx
+++ b/src/components/network-direction-information/network-direction-information.tsx
@@ -5,6 +5,7 @@ import type { Currency } from "@/types/currency";
 import { truncateAddress } from "@/utils/format";
 import { TextMorph } from "torph/react";
 import type { Address } from "viem";
+import cn from "@/utils/classnames";
 
 export interface NetworkDirectionInformationProps {
   network: NetworkTagNetwork;
@@ -13,6 +14,16 @@ export interface NetworkDirectionInformationProps {
   direction: "origin" | "destination";
   currency: Currency;
   hideBalance?: boolean;
+  // Custom recipient props (destination only)
+  destinationWalletConnected?: boolean;
+  isEditingRecipient?: boolean;
+  customRecipientAddress?: string;
+  onCustomRecipientChange?: (v: string) => void;
+  onStartEditRecipient?: () => void;
+  onCancelEditRecipient?: () => void;
+  customAddressError?: string | null;
+  destinationChain?: NetworkTagNetwork;
+  onConnectDestinationWallet?: () => void;
 }
 
 type Props = NetworkDirectionInformationProps;
@@ -24,11 +35,26 @@ export default function NetworkDirectionInformation({
   direction,
   currency,
   hideBalance = false,
+  destinationWalletConnected,
+  isEditingRecipient,
+  customRecipientAddress,
+  onCustomRecipientChange,
+  onStartEditRecipient,
+  onCancelEditRecipient,
+  customAddressError,
+  destinationChain,
+  onConnectDestinationWallet,
 }: Props) {
   const DIRECTION_LABEL: Record<Props["direction"], string> = {
     origin: "From",
     destination: "To",
   };
+
+  const isDestination = direction === "destination";
+  const showNoWalletOptions = isDestination && !destinationWalletConnected && !isEditingRecipient;
+  const showCustomInput =
+    isDestination && !showNoWalletOptions && (isEditingRecipient || !destinationWalletConnected);
+  const showBalance = !hideBalance && !(isDestination && (showCustomInput || showNoWalletOptions));
 
   return (
     <div className="flex flex-col w-full gap-4 rounded-lg bg-[#FAFAFA] p-6">
@@ -37,16 +63,82 @@ export default function NetworkDirectionInformation({
         <NetworkTag network={network} />
       </div>
 
-      <div className="flex w-full items-center justify-between">
-        <span className="text-base text-primary">Wallet address</span>
-        <Tooltip content={walletAddress}>
-          <TextMorph className="cursor-default text-base font-semibold text-primary underline decoration-dotted underline-offset-2">
-            {truncateAddress(walletAddress)}
-          </TextMorph>
-        </Tooltip>
-      </div>
+      {showNoWalletOptions ? (
+        <div className="flex w-full items-center justify-between">
+          <span className="text-base text-primary">No wallet connected</span>
+          <div className="flex flex-col items-end gap-1">
+            {onConnectDestinationWallet && (
+              <button
+                type="button"
+                onClick={onConnectDestinationWallet}
+                className="text-sm font-medium text-primary hover:opacity-70 transition-opacity"
+              >
+                Connect
+              </button>
+            )}
+            {onStartEditRecipient && (
+              <button
+                type="button"
+                onClick={onStartEditRecipient}
+                className="text-xs text-gray-500 hover:text-primary transition-colors underline underline-offset-2"
+              >
+                Enter an address
+              </button>
+            )}
+          </div>
+        </div>
+      ) : showCustomInput ? (
+        <div className="flex flex-col gap-1.5">
+          <div className="flex w-full items-center justify-between">
+            <span className="text-base text-primary">Recipient address</span>
+            {isEditingRecipient && onCancelEditRecipient && (
+              <button
+                type="button"
+                onClick={onCancelEditRecipient}
+                className="text-sm text-gray-500 hover:text-primary transition-colors"
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+          <input
+            type="text"
+            value={customRecipientAddress ?? ""}
+            onChange={(e) => onCustomRecipientChange?.(e.target.value)}
+            placeholder={`Enter ${destinationChain ?? network} address`}
+            className={cn(
+              "w-full rounded border bg-white/80 px-3 py-2 text-sm text-primary font-mono",
+              "placeholder:text-gray-400 focus:outline-none",
+              customAddressError
+                ? "border-red-400 focus:border-red-400"
+                : "border-gray-200 focus:border-highlight/60",
+            )}
+          />
+          {customAddressError && <span className="text-xs text-red-500">{customAddressError}</span>}
+        </div>
+      ) : (
+        <div className="flex w-full items-center justify-between">
+          <span className="text-base text-primary">Wallet address</span>
+          <div className="flex items-center gap-2">
+            <Tooltip content={walletAddress}>
+              <TextMorph className="cursor-default text-base font-semibold text-primary underline decoration-dotted underline-offset-2">
+                {truncateAddress(walletAddress)}
+              </TextMorph>
+            </Tooltip>
+            {isDestination && destinationWalletConnected && onStartEditRecipient && (
+              <button
+                type="button"
+                onClick={onStartEditRecipient}
+                className="text-xs text-gray-500 hover:text-primary transition-colors whitespace-nowrap underline underline-offset-2"
+              >
+                Change recipient
+              </button>
+            )}
+          </div>
+        </div>
+      )}
 
-      {!hideBalance && (
+      {showBalance && (
         <div className="flex w-full items-center justify-between">
           <span className="text-base text-primary">Balance</span>
           <div className="flex items-center gap-1">

--- a/src/domains/bridge/react/bridge.page.tsx
+++ b/src/domains/bridge/react/bridge.page.tsx
@@ -3,6 +3,7 @@ import BridgeInitialStep from "./components/steps/bridge-initial-step";
 import BridgeSuccessStep from "./components/steps/bridge-success-step";
 import { useBridge } from "@/hooks/useBridge";
 import { useBridgeHealthContext } from "@/providers/BridgeHealthProvider";
+import QubicWalletModal from "@/components/wallet-area/modals/qubic-wallet-modal";
 
 export default function BridgePage() {
   const bridge = useBridge();
@@ -34,8 +35,21 @@ export default function BridgePage() {
           error={bridge.error}
           isSolanaToQubic={bridge.isSolanaToQubic}
           isPaused={isPaused}
+          destinationWalletConnected={bridge.destinationWalletConnected}
+          isEditingRecipient={bridge.isEditingRecipient}
+          customRecipientAddress={bridge.customRecipientAddress}
+          onCustomRecipientChange={bridge.setCustomRecipientAddress}
+          onStartEditRecipient={bridge.startEditRecipient}
+          onCancelEditRecipient={bridge.cancelEditRecipient}
+          customAddressError={bridge.customAddressError}
+          onConnectDestinationWallet={bridge.openDestinationWallet}
         />
       )}
+
+      <QubicWalletModal
+        open={bridge.qubicModalOpen}
+        onClose={() => bridge.setQubicModalOpen(false)}
+      />
 
       {bridge.currentBridgeStep === "successful" && (
         <BridgeSuccessStep

--- a/src/domains/bridge/react/components/steps/bridge-initial-step.tsx
+++ b/src/domains/bridge/react/components/steps/bridge-initial-step.tsx
@@ -25,6 +25,15 @@ interface Props {
   error: string | null;
   isSolanaToQubic?: boolean;
   isPaused?: boolean;
+  // Custom recipient
+  destinationWalletConnected: boolean;
+  isEditingRecipient: boolean;
+  customRecipientAddress: string;
+  onCustomRecipientChange: (v: string) => void;
+  onStartEditRecipient: () => void;
+  onCancelEditRecipient: () => void;
+  customAddressError: string | null;
+  onConnectDestinationWallet: () => void;
 }
 
 export default function BridgeInitialStep({
@@ -43,6 +52,14 @@ export default function BridgeInitialStep({
   feesAmount,
   error,
   isPaused,
+  destinationWalletConnected,
+  isEditingRecipient,
+  customRecipientAddress,
+  onCustomRecipientChange,
+  onStartEditRecipient,
+  onCancelEditRecipient,
+  customAddressError,
+  onConnectDestinationWallet,
 }: Props) {
   const isBridgeDisabled = isPaused || !canBridge || isBridging;
 
@@ -98,6 +115,15 @@ export default function BridgeInitialStep({
               balance={destinationWalletConfig.balance}
               direction="destination"
               currency={destinationWalletConfig.currency}
+              destinationWalletConnected={destinationWalletConnected}
+              isEditingRecipient={isEditingRecipient}
+              customRecipientAddress={customRecipientAddress}
+              onCustomRecipientChange={onCustomRecipientChange}
+              onStartEditRecipient={onStartEditRecipient}
+              onCancelEditRecipient={onCancelEditRecipient}
+              customAddressError={customAddressError}
+              destinationChain={destinationNetwork}
+              onConnectDestinationWallet={onConnectDestinationWallet}
             />
           </div>
         </div>

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -9,6 +9,7 @@ import { useQubicWallet } from "@/providers/QubicWalletProvider";
 import { useBridgeOutbound } from "@/hooks/useBridgeOutbound";
 import { useBridgeInbound } from "@/hooks/useBridgeInbound";
 import { qubicIdentityToBytes } from "@/lib/bridge/qubicAddress";
+import { isValidQubicAddress, isValidSolanaAddress } from "@/lib/bridge/addressValidation";
 import { displayToRaw } from "@/lib/bridge/amounts";
 import { bytesToHex } from "@/lib/qubicIdentity";
 import { useFeeEstimate } from "@/hooks/useFeeEstimate";
@@ -22,6 +23,9 @@ export function useBridge() {
   const [bridgeAmount, setBridgeAmount] = useState("");
   const [originNetwork, setOriginNetwork] = useState<NetworkTagNetwork>(NETWORK.Solana);
   const [localError, setLocalError] = useState<string | null>(null);
+  const [customRecipientAddress, setCustomRecipientAddress] = useState("");
+  const [isEditingRecipient, setIsEditingRecipient] = useState(false);
+  const [qubicModalOpen, setQubicModalOpen] = useState(false);
 
   const solanaWallet = useSolanaWallet();
   const qubicWallet = useQubicWallet();
@@ -30,6 +34,19 @@ export function useBridge() {
 
   const isSolanaToQubic = originNetwork === NETWORK.Solana;
   const destinationNetwork = isSolanaToQubic ? NETWORK.Qubic : NETWORK.Solana;
+
+  const destinationConnectedAddress = isSolanaToQubic ? qubicWallet.address : solanaWallet.address;
+  const usesCustomAddress = isEditingRecipient || !destinationConnectedAddress;
+
+  const customAddressValid = customRecipientAddress
+    ? (isSolanaToQubic ? isValidQubicAddress : isValidSolanaAddress)(customRecipientAddress)
+    : null;
+
+  const effectiveDestinationAddress: string | null = usesCustomAddress
+    ? customAddressValid
+      ? customRecipientAddress
+      : null
+    : (destinationConnectedAddress ?? null);
 
   let activeSourceNonce: string | null = null;
 
@@ -48,15 +65,20 @@ export function useBridge() {
     trackingError,
   } = useOrderTracking(activeSourceNonce);
 
+  const solanaFeeAddr = isSolanaToQubic ? solanaWallet.address : effectiveDestinationAddress;
+  const qubicFeeAddr = isSolanaToQubic ? effectiveDestinationAddress : qubicWallet.address;
+
   const { estimate, isEstimating, estimateError } = useFeeEstimate(
     originNetwork,
     bridgeAmount,
-    solanaWallet.address ?? null,
-    qubicWallet.address ?? null,
+    solanaFeeAddr ?? null,
+    qubicFeeAddr ?? null,
   );
 
   const switchDirection = () => {
     setOriginNetwork((prev) => (prev === NETWORK.Qubic ? NETWORK.Solana : NETWORK.Qubic));
+    setCustomRecipientAddress("");
+    setIsEditingRecipient(false);
   };
 
   const handleBridge = async () => {
@@ -73,9 +95,8 @@ export function useBridge() {
       return;
     }
 
-    const destinationConnected = isSolanaToQubic ? !!qubicWallet.address : !!solanaWallet.address;
-    if (!destinationConnected) {
-      toast.error(`Please connect your ${isSolanaToQubic ? "Qubic" : "Solana"} wallet`);
+    if (!effectiveDestinationAddress) {
+      toast.error(`Please enter a valid recipient ${isSolanaToQubic ? "Qubic" : "Solana"} address`);
       return;
     }
 
@@ -95,7 +116,7 @@ export function useBridge() {
     let result;
 
     if (isSolanaToQubic) {
-      const toAddress = qubicIdentityToBytes(qubicWallet.address as string);
+      const toAddress = qubicIdentityToBytes(effectiveDestinationAddress);
       const { orderEra } = await queryGetConfig();
       result = await bridge.sendOutbound({
         amount: displayToRaw(bridgeAmount),
@@ -106,7 +127,7 @@ export function useBridge() {
     } else {
       result = await inbound.sendLock({
         amount: BigInt(Math.floor(parseFloat(bridgeAmount))),
-        toSolanaAddress: solanaWallet.address as string,
+        toSolanaAddress: effectiveDestinationAddress,
         relayerFee: BigInt(Math.floor(parseFloat(relayerFee))),
       });
     }
@@ -122,6 +143,8 @@ export function useBridge() {
     setBridgeAmount("");
     setLocalError(null);
     setCurrentBridgeStep("initial");
+    setCustomRecipientAddress("");
+    setIsEditingRecipient(false);
   };
 
   const originWalletConfig: NetworkDirectionInformationProps = isSolanaToQubic
@@ -140,17 +163,21 @@ export function useBridge() {
         direction: "origin",
       };
 
+  const destinationDisplayAddress = (effectiveDestinationAddress ??
+    destinationConnectedAddress ??
+    "Not connected") as Address;
+
   const destinationWalletConfig: NetworkDirectionInformationProps = isSolanaToQubic
     ? {
         network: NETWORK.Qubic,
-        walletAddress: (qubicWallet.address ?? "Not connected") as Address,
+        walletAddress: destinationDisplayAddress,
         balance: qubicWallet.balance ?? "0",
         currency: "QUBIC",
         direction: "destination",
       }
     : {
         network: NETWORK.Solana,
-        walletAddress: (solanaWallet.address ?? "Not connected") as Address,
+        walletAddress: destinationDisplayAddress,
         balance: solanaWallet.balance ?? "0",
         currency: "wQUBIC",
         direction: "destination",
@@ -159,6 +186,11 @@ export function useBridge() {
   const totalProgramFees = estimate?.totalBridgeFee ?? "0";
   const relayerFee = estimate?.relayerFee ?? "0";
   const canBridge = !!estimate && !isEstimating;
+
+  const customAddressError =
+    customRecipientAddress && customAddressValid === false
+      ? `Invalid ${isSolanaToQubic ? "Qubic" : "Solana"} address`
+      : null;
 
   return {
     currentBridgeStep,
@@ -186,5 +218,20 @@ export function useBridge() {
     orderStatus,
     destinationTrxHash,
     isTrackingOrder,
+    customRecipientAddress,
+    setCustomRecipientAddress,
+    isEditingRecipient,
+    startEditRecipient: () => setIsEditingRecipient(true),
+    cancelEditRecipient: () => {
+      setCustomRecipientAddress("");
+      setIsEditingRecipient(false);
+    },
+    customAddressError,
+    destinationWalletConnected: !!destinationConnectedAddress,
+    openDestinationWallet: isSolanaToQubic
+      ? () => setQubicModalOpen(true)
+      : () => solanaWallet.openModal(),
+    qubicModalOpen,
+    setQubicModalOpen,
   };
 }

--- a/src/lib/bridge/addressValidation.ts
+++ b/src/lib/bridge/addressValidation.ts
@@ -1,0 +1,16 @@
+import { PublicKey } from "@solana/web3.js";
+
+const QUBIC_IDENTITY_RE = /^[A-Z]{60}$/;
+
+export function isValidQubicAddress(address: string): boolean {
+  return QUBIC_IDENTITY_RE.test(address);
+}
+
+export function isValidSolanaAddress(address: string): boolean {
+  try {
+    new PublicKey(address);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Closes [CU-86ca4x08z](https://app.clickup.com/t/86ca4x08z)

The bridge currently requires both wallets to be connected and always sends funds to the connected destination wallet. This PR adds a customizable recipient address field so users can bridge to any valid address, regardless of whether a destination wallet is connected.

**Behavior by wallet state:**
- **Both wallets connected** — the connected destination wallet address is shown by default, with a "Change recipient" button to enter a custom address; Cancel restores the default
- **Only source wallet connected** — a recipient address input is shown directly (no default to fall back to)
- **No wallet connected** — same as above; the bridge button remains disabled until a source wallet is connected

**Address validation (live, as the user types):**
- Qubic: `/^[A-Z]{60}$/`
- Solana: `new PublicKey(address)` try/catch (via `@solana/web3.js`)

Invalid input shows an inline error, clears the fee estimate, and disables the Bridge button. The custom recipient is reset when the user switches direction or starts a new bridge.

## Changes

- `src/lib/bridge/addressValidation.ts` — new `isValidQubicAddress` / `isValidSolanaAddress` utilities
- `src/hooks/useBridge.ts` — custom recipient state, effective destination address derivation, fee estimate and bridge execution updated to use it
- `src/components/network-direction-information/network-direction-information.tsx` — destination section now renders three states (connected/editing/no-wallet) with inline validation feedback
- `src/domains/bridge/react/components/steps/bridge-initial-step.tsx` — passes new props to destination info component
- `src/domains/bridge/react/bridge.page.tsx` — wires new hook values through to the step component

## Test plan

- [x] Both wallets connected → destination shows wallet address + "Change recipient" button
- [x] Click "Change recipient" → input appears; enter invalid address → inline error, Bridge disabled; enter valid address → fees recalculate, Bridge enabled
- [x] Click "Cancel" → reverts to connected wallet address
- [x] Disconnect destination wallet → input shown directly, no cancel button
- [x] Switch direction → custom recipient resets
- [x] Complete a bridge → click "New bridge" → custom recipient resets
